### PR TITLE
Sqlite improvements

### DIFF
--- a/libnwccc.nim
+++ b/libnwccc.nim
@@ -105,6 +105,8 @@ proc processManifest(base_url, mf_hash: string): Future[bool] {.async.} =
     let fqurl = base_url & "/manifests/" & mf_hash
     try:
         let mfRaw = await http.getContent(fqurl)
+        if secureHash(mfRaw) != parseSecureHash(mfHash):
+            raise newException(ValueError, "Checksum mismatch")
         let mf = readManifest(newStringStream(mf_raw))
         info "  Got " & $mf.entries.len & " entries, total size " & $totalSize(mf)
         db.exec(sql"BEGIN")


### PR DESCRIPTION
* Checksum downloaded manifests before writing them to DB.
  * Also added checksum checks for downloaded swarm files while I was there.
  * I haven't actually tested this because I did not have a .nwc file at hand that actually pulled data from the swarm. ❗ 
* Add some rudimentary migration support to the DB schema, using the sqlite-builtin `user_version` pragma.
  * Also added a check for too-new database files.
* Add support for blacklisting manifests that checksum OK but somehow fail to parse by nwsync. This fixes #21 
  * Do we want a blacklist reason here in the DB?
  * Do you want a timestamp in the DB for the blacklist? e.g. to evict really old hashes at some point.
  * Do you want the originating URL that blacklisted the manifest?
