### PR TITLE
Don't insert duplicate entries into db

### DIFF
--- a/asynchttppool.nim
+++ b/asynchttppool.nim
@@ -53,7 +53,7 @@ proc downloadAndResolve(pool: AsyncHttpPool, ahttp: AsyncHttpClient, qe: QueueEn
     if not isNil qe.progress:
       result = qe.progress(total, progress, speed)
     else:
-      info qe.url, ": ", progress, " of ", total, ", current rate: ", speed div 1000, "kb/s"
+      debug qe.url, ": ", progress, " of ", total, ", current rate: ", speed div 1000, "kb/s"
 
   # We start one async timer per inflight xfer to check if we're timing out - simple UX
   addTimer(1000, false) do (fd: AsyncFD) -> bool:
@@ -72,7 +72,7 @@ proc downloadAndResolve(pool: AsyncHttpPool, ahttp: AsyncHttpClient, qe: QueueEn
     # Otherwise, report inactivity every
     if now - qe.lastProgressReport > initDuration(seconds = 6):
       qe.lastProgressReport = now
-      info pool, " ", qe.url, ": Waiting for data .. (for ", (now - qe.transferStart).inSeconds, " s)"
+      debug pool, " ", qe.url, ": Waiting for data .. (for ", (now - qe.transferStart).inSeconds, " s)"
     false
 
   info pool, " starting download: ", qe.url

--- a/nwn_ccc.nim
+++ b/nwn_ccc.nim
@@ -19,7 +19,7 @@ Options:
   -f, --filelist=<filelist>    Process all NWC files in <filelist>
   -u, --update-cache           Update local manifest cache
   -l, --local-cache=<dir>      Also search <dir> for local files before downloading
-  --parallel=<N>               Parallel downloads [default: 5]
+  --parallel=<N>               Parallel downloads [default: 20]
 
   -v, --verbose                Verbose prints as files are being processed
   -q, --quiet                  Suppresses all non-error prints


### PR DESCRIPTION
Arelith has 5 servers advertising the same manifest, so it would end up with five copies of the whole thing, both in `manifests` and `resources` table.

I couldn't easily migrate the schema, but it doesn't really matter either. You can nuke and recreate the db to clean it up, or just leave it and it'll clean itself eventually.